### PR TITLE
Added a simple collector that aggregates call stacks and their counts

### DIFF
--- a/flameiq/engine/collector.py
+++ b/flameiq/engine/collector.py
@@ -1,0 +1,23 @@
+from collections import defaultdict
+from typing import List, Dict, Any
+
+class Collector:
+    """
+    A simple collector that aggregates call stacks and their counts.
+    """
+    def __init__(self):
+        self._data = defaultdict(int)
+
+    def add_sample(self, stack: List[Dict[str, Any]]):
+        """
+        Adds a single call stack sample to the aggregated data.
+        """
+        # Create a simple string representation of the stack to use as a key
+        stack_path = ';'.join([f"{f['file']}:{f['function']}" for f in stack])
+        self._data[stack_path] += 1
+
+    def get_aggregated_data(self) -> Dict[str, int]:
+        """
+        Returns the final aggregated data.
+        """
+        return dict(self._data)


### PR DESCRIPTION
This pull request introduces the initial Collector component. This is a critical step in our development plan, as it allows us to test the fundamental logic of data aggregation before moving to the more complex, high-performance C extensions.

**Key Changes**
**flameiq/engine/collector.py** : This file introduces a basic Collector class. It receives raw stack samples from the Sampler and efficiently aggregates them into a dictionary, providing a simplified model for the final data collection